### PR TITLE
Plugin cleanup

### DIFF
--- a/src/AssetReplacer/BepinexPlugin.cs
+++ b/src/AssetReplacer/BepinexPlugin.cs
@@ -27,7 +27,16 @@ public class Plugin : BaseUnityPlugin
 
     private void Start()
     {
-        string texturesFolderPath = Path.Combine(Assembly.GetExecutingAssembly().Location.Substring(0, Assembly.GetExecutingAssembly().Location.Length - 17), "Texture2D");
+        /*
+        Changes: Path resolution for texture dir
+        Explanation: 
+            The original code simply deleted the last 17 characters from the executing assembly's path
+            so I assumed you wanted to go up one level from the location of the current assembly
+            Info.Location always has your plugin's location so it'll work no matter how the user
+            installs it. You probably wanna just have the location be currentFolder + "Texture2D" but
+            this is my best interpretation of you were doing previously.
+        */
+        string texturesFolderPath = Path.GetFullPath(Path.Combine(Info.Location.Replace(Path.GetFileName(Info.Location), ""), "..", "Texture2D"));
 
         this.patchAssets(texturesFolderPath);
     }

--- a/src/AssetReplacer/BepinexPlugin.cs
+++ b/src/AssetReplacer/BepinexPlugin.cs
@@ -31,12 +31,11 @@ public class Plugin : BaseUnityPlugin
         Changes: Path resolution for texture dir
         Explanation: 
             The original code simply deleted the last 17 characters from the executing assembly's path
-            so I assumed you wanted to go up one level from the location of the current assembly
+            so I assumed you wanted the current directory of the current assembly
             Info.Location always has your plugin's location so it'll work no matter how the user
-            installs it. You probably wanna just have the location be currentFolder + "Texture2D" but
-            this is my best interpretation of you were doing previously.
+            installs it.
         */
-        string texturesFolderPath = Path.GetFullPath(Path.Combine(Info.Location.Replace(Path.GetFileName(Info.Location), ""), "..", "Texture2D"));
+        string texturesFolderPath = Path.GetFullPath(Path.Combine(Info.Location.Replace(Path.GetFileName(Info.Location), ""), "Texture2D"));
 
         this.patchAssets(texturesFolderPath);
     }


### PR DESCRIPTION
New features:

* Plugin uses its own base directory rather than GetExecutingAssembly. This makes the plugin directory agnostic
* Plugin uses Path methods rather than trimming a path string manually (this is the recommended way to do paths in C# so they remain useful cross-platform)